### PR TITLE
Enable flexible daily uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ python MAIN.py --bp_s       # Skip GPT storytelling
 python MAIN.py --bp_a       # Skip audio generation
 ```
 
+### 📅 Upload Scheduling
+
+`k_youtube.py` keeps a list of upload hours (``UPLOAD_TIMES``) and by default
+posts at **10:00** and **16:00** every day.  It checks `upload_time.json` for
+the previously scheduled slot and picks the next hour from the list; when all
+times for the day are used, scheduling rolls over to the first slot of the next
+day.  The file is updated after each call so uploads remain evenly spaced.
+
 ---
 
 ## 📂 Folder Structure


### PR DESCRIPTION
## Summary
- keep list of allowed hours as `UPLOAD_TIMES`
- compute next slot based on last scheduled time in `upload_time.json`
- clarify scheduling behavior in README

## Testing
- `python -m py_compile k_youtube.py`


------
https://chatgpt.com/codex/tasks/task_e_683f5bf0e91883269c93806b2fd197c7