### PR TITLE
Add global progress bar and hide verbose output

### DIFF
--- a/k_gpt4o.py
+++ b/k_gpt4o.py
@@ -73,7 +73,7 @@ def ytb(project, prompt, reddit, rtitle, link):
 
     descrpt_tags = ""
     for tag in tags:
-        descrpt_tags += f"#{tag.strip().replace(" ","").lower()} "
+        descrpt_tags += f'#{tag.strip().replace(" ", "").lower()} '
 
     description += descrpt_tags
 

--- a/k_movie.py
+++ b/k_movie.py
@@ -18,7 +18,7 @@ def cropping(input, output, beg, duration):
     end_time = beg + duration
 
     # Subclip the video to the desired duration
-    subclip = video.subclip(beg, end_time)
+    subclip = video.subclipped(beg, end_time)
 
     # Resize the video to 1080x1920 (9:16 aspect ratio)
     resized_video = subclip.resized(height=1280).resized(width=720)

--- a/k_movie.py
+++ b/k_movie.py
@@ -18,7 +18,7 @@ def cropping(input, output, beg, duration):
     end_time = beg + duration
 
     # Subclip the video to the desired duration
-    subclip = video.subclipped(beg, end_time)
+    subclip = video.subclip(beg, end_time)
 
     # Resize the video to 1080x1920 (9:16 aspect ratio)
     resized_video = subclip.resized(height=1280).resized(width=720)
@@ -46,7 +46,14 @@ def cropping(input, output, beg, duration):
     cropped_video = resized_video.cropped(width=crop_width, height=crop_height, x_center=x_center, y_center=y_center)
 
     # Export the cropped and shortened video
-    cropped_video.write_videofile(output, codec="libx264", audio=False)
+    # Hide verbose moviepy logs but keep the progress bar
+    cropped_video.write_videofile(
+        output,
+        codec="libx264",
+        audio=False,
+        verbose=False,
+        logger="bar",
+    )
 
 def audio(video_in, audio_in, output):
 # Construct the ffmpeg command
@@ -68,7 +75,13 @@ def audio(video_in, audio_in, output):
 
     # Run the command using subprocess
     try:
-        subprocess.run(command, check=True)
+        # Suppress ffmpeg output to keep the terminal clean
+        subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
     except:
         print("error")
 
@@ -122,7 +135,14 @@ def subtitles(srt_path, video_input, video_output):
     final_video = CompositeVideoClip([video] + subtitle_clips)
 
     # Write the final output
-    final_video.write_videofile(video_output, codec='libx264', audio_codec='aac')
+    # Hide verbose moviepy logs but keep the progress bar
+    final_video.write_videofile(
+        video_output,
+        codec='libx264',
+        audio_codec='aac',
+        verbose=False,
+        logger='bar',
+    )
 
     # Clean up
     video.close()
@@ -185,7 +205,14 @@ def upscale_to_4k_youtube(input_path, output_path):
     
     video = VideoFileClip(input_path)
     upscaled = video.resized(height=target_height, width=target_width)
-    upscaled.write_videofile(temp_path, codec='libx264', preset='ultrafast', audio_codec='aac')
+    upscaled.write_videofile(
+        temp_path,
+        codec='libx264',
+        preset='ultrafast',
+        audio_codec='aac',
+        verbose=False,
+        logger='bar',
+    )
 
     # Step 2: Re-encode with YouTube 4K recommended settings via ffmpeg
     command = [
@@ -207,7 +234,12 @@ def upscale_to_4k_youtube(input_path, output_path):
     ]
 
     try:
-        subprocess.run(command, check=True)
+        subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
         print(f"✅ Exported YouTube 4K ready video to: {output_path}")
     except subprocess.CalledProcessError as e:
         print(f"❌ ffmpeg error: {e}")

--- a/k_youtube.py
+++ b/k_youtube.py
@@ -89,6 +89,7 @@ def get_authenticated_service():
 def publish(file_path, title, description, tags):
     youtube = get_authenticated_service()
     scheduled_time = get_scheduled_time()
+    print(f"\n📅 Scheduled upload time: {scheduled_time}\n")
     body = {
         'snippet': {
             'title': (title[:96] + '...') if len(title) > 96 else title,
@@ -114,13 +115,13 @@ def publish(file_path, title, description, tags):
 
     response = upload_chunks(request)
     if response:
-        print("Upload Complete!")
+        print("\n✅ Upload complete!")
         # Extract video ID and print the link and title
         video_id = response['id']
         video_url = f"https://www.youtube.com/watch?v={video_id}"
-        print(f"Video URL: {video_url}")
-        print(f"Title: {title}")
-        return response
+        print(f"🔗 Video URL: {video_url}")
+        print(f"🏷️  Title: {title}\n")
+        return video_url, scheduled_time
     else:
-        print("Upload failed.")
-        return None
+        print("❌ Upload failed.")
+        return None, scheduled_time


### PR DESCRIPTION
## Summary
- suppress `moviepy` and `ffmpeg` logs while keeping progress bars
- show the YouTube scheduled time with a nicer message
- add an overall pipeline progress bar using `tqdm`
- fix quoting in tag generation

## Testing
- `python -m py_compile main.py k_movie.py k_youtube.py k_reddit.py k_gpt4o.py k_srt.py`


------
https://chatgpt.com/codex/tasks/task_e_683f61917c648326a9009a5c3ea180ef