### PR TITLE
Optimize media duration lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ python MAIN.py --project
 python MAIN.py --bp_r       # Skip Reddit fetching
 python MAIN.py --bp_s       # Skip GPT storytelling
 python MAIN.py --bp_a       # Skip audio generation
+python MAIN.py --cpu        # Force CPU-only encoding
 ```
 
 ### 📅 Upload Scheduling


### PR DESCRIPTION
## Summary
- speed up duration checks in `main.py` and `k_movie.py`
- add optional GPU accelerated encoding using NVENC
- default to GPU acceleration; use `--cpu` flag to force CPU only

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68448e75d6b883269869037365d97f07