### PR TITLE
Add batch_run script for repeated runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ python MAIN.py
 python MAIN.py --project
 ```
 
+### 🎞️ Batch Processing
+
+Run the audio normalizer and then execute `MAIN.py` repeatedly. Specify the
+number of successful runs with `-n`:
+
+```bash
+python batch_run.py -n 10
+```
+
+Failed runs are retried until the requested count is reached.
+
 ### ⛔ Skip Individual Steps (for testing)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ python MAIN.py --project
 
 ### 🎞️ Batch Processing
 
-Run the audio normalizer and then execute `MAIN.py` repeatedly. Specify the
-number of successful runs with `-n`:
+Run the audio normalizer and then execute `MAIN.py` repeatedly. By default, the
+script performs 10 successful runs. You can override this number with `-n`:
 
 ```bash
-python batch_run.py -n 10
+python batch_run.py        # runs MAIN until 10 successes
+python batch_run.py -n 3   # override to run 3 successes
 ```
 
 Failed runs are retried until the requested count is reached.

--- a/batch_run.py
+++ b/batch_run.py
@@ -25,8 +25,8 @@ def main():
         description='Normalize audio then run main.py multiple times.'
     )
     parser.add_argument(
-        '-n', '--number', type=int, default=1,
-        help='Number of successful MAIN runs to execute'
+        '-n', '--number', type=int, default=10,
+        help='Number of successful MAIN runs to execute (default: 10)'
     )
     parser.add_argument(
         'main_args', nargs=argparse.REMAINDER,

--- a/batch_run.py
+++ b/batch_run.py
@@ -1,0 +1,54 @@
+import argparse
+import os
+import subprocess
+import sys
+
+import normalize_audio
+
+
+def run_main(extra_args=None):
+    """Run main.py as a subprocess and return True if successful."""
+    script_path = os.path.join(os.path.dirname(__file__), 'main.py')
+    cmd = [sys.executable, script_path]
+    if extra_args:
+        cmd.extend(extra_args)
+    try:
+        subprocess.run(cmd, check=True)
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"MAIN failed with exit code {e.returncode}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Normalize audio then run main.py multiple times.'
+    )
+    parser.add_argument(
+        '-n', '--number', type=int, default=1,
+        help='Number of successful MAIN runs to execute'
+    )
+    parser.add_argument(
+        'main_args', nargs=argparse.REMAINDER,
+        help='Arguments to pass to main.py (use -- before these arguments)'
+    )
+    args = parser.parse_args()
+
+    # Step 1: normalize audio
+    normalize_audio.normalize_folder()
+
+    success = 0
+    attempts = 0
+    while success < args.number:
+        attempts += 1
+        print(f"-- RUNNING MAIN ({attempts}) --")
+        if run_main(args.main_args):
+            success += 1
+        else:
+            print('MAIN errored, retrying...')
+
+    print(f"Completed {success} successful runs after {attempts} attempts.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a new helper `batch_run.py` to normalize audio then execute MAIN repeatedly
- document batch processing usage in README

## Testing
- `python -m py_compile batch_run.py k_movie.py k_srt.py main.py k_gpt4o.py k_reddit.py k_youtube.py normalize_audio.py`

------
https://chatgpt.com/codex/tasks/task_e_6844feb6e8c88326825893b4b5068791